### PR TITLE
Include SortingHat Docker images with OpenInfraID

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,90 @@
+name: Build & push Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Docker image version"
+        type: string
+        required: true
+
+env:
+  SERVER_IMAGE_NAME: "bitergia/bitergia-analytics-sortinghat"
+  WORKER_IMAGE_NAME: "bitergia/bitergia-analytics-sortinghat-worker"
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    needs: [build-package]
+    environment: docker-release
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # 3.3.0
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2.8.1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+        with:
+          platforms: linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # v2.4.1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Server Docker metadata
+        id: meta-server
+        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 # v4.3.0
+        with:
+          images: |
+            ${{ env.SERVER_IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.version }}
+
+      - name: Server Build and push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          file: "docker-sortinghat/server.dockerfile"
+          push: true
+          tags: ${{ steps.meta-server.outputs.tags }}
+
+      - name: Server Sign image with a key
+        run: |
+          cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
+        env:
+          TAGS: ${{ steps.meta-server.outputs.tags }}
+          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+
+      - name: Worker Docker metadata
+        id: meta-worker
+        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 # v4.3.0
+        with:
+          images: |
+            ${{ env.WORKER_IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.version }}            
+
+      - name: Worker Build and push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          file: "docker-sortinghat/worker.dockerfile"
+          push: true
+          tags: ${{ steps.meta-worker.outputs.tags }}
+
+      - name: Worker Sign image with a key
+        run: |
+          cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
+        env:
+          TAGS: ${{ steps.meta-worker.outputs.tags }}
+          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}

--- a/docker-sortinghat/README.md
+++ b/docker-sortinghat/README.md
@@ -1,0 +1,65 @@
+# Bitergia Analytics image for SortingHat
+
+SortingHat is a tool to manage identities and is part of GrimoireLab
+platform.
+
+For more information about GrimoireLab and SortingHat, please visit
+our [website](https://chaoss.github.io/grimoirelab/).
+
+
+## How to use this image
+
+### Quickstart 
+
+These commands will start a SortingHat server container in developer mode
+with a MySQL and Redis server containers. The service will run on an HTTP
+server on `localhost:8000`. You can access it with credentials `admin:admin`.
+Modify `SORTINGHAT_SUPERUSER_*` env vars, if you want different values.
+
+```
+$ docker network create sh
+
+$ docker run --rm --net sh --name mysqldb -e 'MYSQL_ALLOW_EMPTY_PASSWORD=yes' mysql:8.0.22
+
+$ docker run --rm --net sh --name redisdb redis:latest redis-server --appendonly yes
+
+$ docker run --rm --net sh -p 8000:8000 --name sortinghat \
+    -e 'SORTINGHAT_SECRET_KEY=secret' \
+    -e 'SORTINGHAT_DB_HOST=mysqldb' \
+    -e 'SORTINGHAT_REDIS_HOST=redisdb' \
+    -e 'SORTINGHAT_SUPERUSER_USERNAME=admin' \
+    -e 'SORTINGHAT_SUPERUSER_PASSWORD=admin' \
+    -e 'SORTINGHAT_HTTP_DEV=0.0.0.0:8000' \
+    bitergia/bitergia-analytics-sortinghat --dev
+```
+
+To run a worker that will execute jobs, use the next command:
+
+```
+$ docker run --rm --net sh --name sortinghat-worker-1 \
+    -e 'SORTINGHAT_SECRET_KEY=secret' \
+    -e 'SORTINGHAT_DB_HOST=mysqldb' \
+    -e 'SORTINGHAT_REDIS_HOST=redisdb' \
+    bitergia/bitergia-analytics-sortinghat-worker
+```
+
+
+## Building the image
+
+To build the images (server and worker), run `docker build` command.
+
+```
+$ docker build -f server.dockerfile -t bitergia/bitergia-analytics-sortinghat .
+
+$ docker build -f worker.dockerfile -t bitergia/bitergia-analytics-sortinghat-worker .
+```
+
+
+## License
+
+SortingHat is licensed under GNU General Public License (GPL), version 3
+or later.
+
+However, this image is based on the [Debian docker image](https://hub.docker.com/_/debian),
+Check their [license information](https://www.debian.org/social_contract#guidelines)
+for the type of software is contained in this image.

--- a/docker-sortinghat/server.dockerfile
+++ b/docker-sortinghat/server.dockerfile
@@ -1,0 +1,4 @@
+FROM grimoirelab/sortinghat:latest
+
+RUN . /opt/venv/bin/activate && \
+    pip install sortinghat-openinfra

--- a/docker-sortinghat/worker.dockerfile
+++ b/docker-sortinghat/worker.dockerfile
@@ -1,0 +1,4 @@
+FROM grimoirelab/sortinghat-worker:latest
+
+RUN . /opt/venv/bin/activate && \
+    pip install sortinghat-openinfra


### PR DESCRIPTION
This PR includes the Dockerfile to create the images for the SortingHat server and worker OpenInfraID plugin installed.

This PR depends on https://github.com/bitergia-analytics/bitergia-analytics-sortinghat-openinfra/pull/1 and the Python package created.