### PR TITLE
[docker] Include PublicInbox backend in the image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,3 +9,6 @@ LABEL org.opencontainers.image.url="https://bitergia.com/"
 LABEL org.opencontainers.image.documentation="https://github.com/bitergia/bitergia-analytics/"
 LABEL org.opencontainers.image.vendor="Bitergia"
 LABEL org.opencontainers.image.authors="sduenas@bitergia.com"
+
+RUN sudo pip install perceval-public-inbox
+RUN sudo pip install grimoire-elk-public-inbox


### PR DESCRIPTION
This PR installs `perceval-public-inbox` and `grimoire-elk-public-inbox` Python packages in the GrimoireLab image.