### PR TITLE
Upgrade to GrimoireLab 0.14.0

### DIFF
--- a/docker-sortinghat/server.dockerfile
+++ b/docker-sortinghat/server.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat:0.13.0
+FROM grimoirelab/sortinghat:0.14.0
 
 ADD settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings.py
 

--- a/docker-sortinghat/worker.dockerfile
+++ b/docker-sortinghat/worker.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat-worker:0.13.0
+FROM grimoirelab/sortinghat-worker:0.14.0
 
 ADD settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings.py
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM grimoirelab/grimoirelab:0.13.0
+FROM grimoirelab/grimoirelab:0.14.0
 
 LABEL org.opencontainers.image.title="Bitergia Analytics"
 LABEL org.opencontainers.image.description="Bitergia Analytics service"


### PR DESCRIPTION
This commit upgrades the components of BAP to use GrimoireLab 0.14.0.