### PR TITLE
Automate release process

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,13 @@
+name: Check changelog file included
+
+on:
+  pull_request:
+    paths:
+      - 'docker/**'
+      - 'docker-sortinghat/**'
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bitergia/release-tools-check-changelog@master

--- a/.github/workflows/release-bap-component.yml
+++ b/.github/workflows/release-bap-component.yml
@@ -1,0 +1,226 @@
+name: Release BAP component
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version number to use'
+        type: string
+        required: true
+      git_email:
+        description: 'Git config email'
+        type: string
+        required: true
+      git_name:
+        description: 'Git config name'
+        type: string
+        required: true
+      release_candidate:
+        description: 'Create a release candidate version'
+        type: string
+        required: true
+      module_name:
+        description: 'Name of the module'
+        type: string
+        required: true
+      module_repository:
+        description: 'Repository of the module'
+        type: string
+        required: true
+      module_directory:
+        description: 'Location of the module in Bitergia Analytics'
+        type: string
+        required: true
+      forced_version:
+        description: 'Force version when there are no changes.'
+        type: string
+        required: true
+      plugin_url:
+        description: 'Installable URL for Bitergia Analytics plugin.'
+        type: string
+        required: false
+    secrets:
+      access_token:
+        description: 'Token for updating repositories'
+        required: true
+
+    outputs:
+      notes:
+        description: "Notes content for the package"
+        value: ${{ jobs.release.outputs.notes }}
+      plugin_url:
+        description: "Installable URL for BAP plugin"
+        value: ${{ jobs.release.outputs.plugin_url }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: bap-release
+    outputs:
+      notes: ${{ steps.notes.outputs.notes }}
+      plugin_url: ${{ steps.assets.outputs.plugin_url }}
+    
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: ${{ inputs.module_repository }}
+          path: ${{ inputs.module_directory }}
+          token: '${{ secrets.access_token }}'
+          fetch-depth: 0
+      
+      - name: Set up Git config
+        run: |
+          git config --global user.email "${{ inputs.git_email }}"
+          git config --global user.name "${{ inputs.git_name }}"
+
+      - name: Install release-tools
+        run: pip install git+https://github.com/Bitergia/release-tools.git#egg=release-tools
+
+      - name: Update version in JSON files
+        if: ${{ inputs.module_directory == 'bitergia-analytics-plugin' }}
+        shell: bash
+        run: |
+          package_contents="$(jq '.version = "${{ inputs.version }}"' package.json)" && \
+          echo -E "${package_contents}" > package.json
+          osd_contents="$(jq '.version = "${{ inputs.version }}"' opensearch_dashboards.json)" && \
+          echo -E "${osd_contents}" > opensearch_dashboards.json
+          echo ${osd_contents}
+        working-directory: ${{ inputs.module_directory }}
+      
+      - id: version
+        name: Update version file
+        if: ${{ inputs.module_directory != 'bitergia-analytics-plugin' }}
+        shell: bash
+        run: |
+          new_version=${{ inputs.version }}
+          echo $new_version > version
+        working-directory: ${{ inputs.module_directory }}
+
+      - name: Update plugin URL in Dockerfile
+        if: ${{ inputs.module_directory == 'bitergia-analytics-opensearch-dashboards' }}
+        id: dockerfile
+        shell: bash
+        run: |
+          url='${{ inputs.plugin_url }}'
+          line="RUN opensearch-dashboards-plugin install $url"
+          sed -i "/bitergia-analytics-plugin/s|.*|$line|" Dockerfile
+        working-directory: ${{ inputs.module_directory }}
+      
+      - id: notes
+        name: Generate release notes
+        run: |
+          version=${{ inputs.version }}
+          eof="EOF$(date +%s)"
+          release_file="releases/$version.md"
+          if [ ${{ inputs.release_candidate }} == 'true' ]
+          then
+            newsArg=''
+            rcArg='--pre-release'
+          else
+            newsArg='--news'
+            rcArg=''
+          fi
+
+          if [ ${{ inputs.forced_version }} != true ]
+          then
+            notes "${{ inputs.module_name }}" $version $newsArg --authors $rcArg
+          else
+            module_name=${{ inputs.module_name }}
+            today=$(date -u "+%Y-%m-%d")
+            cat << EOF > $release_file
+            ## $module_name $version - ($today)
+            
+            * No changes on this component. The version is bumped to align it
+              with the rest of the components.
+          EOF
+            # Update NEWS file if it is not a release candidate
+            if [ ${{ inputs.release_candidate }} != 'true' ]
+            then
+              mv NEWS old_NEWS
+              echo -e "# Releases\n" >> NEWS
+              cat $release_file >> NEWS
+              cat old_NEWS | tail -n +2 >> NEWS
+              rm old_NEWS
+            fi
+          fi
+
+          # Save release notes in 'notes' output
+          echo 'notes<<$eof' >> $GITHUB_OUTPUT
+          cat $release_file >> $GITHUB_OUTPUT
+          echo '$eof' >> $GITHUB_OUTPUT
+        working-directory: ${{ inputs.module_directory }}
+      
+      - id: current_time
+        name: Store current time to get the release workflow
+        run: |
+          datetime=$(date +"%Y-%m-%dT%H:%M:%S%z")
+          echo "datetime=$datetime" >> $GITHUB_OUTPUT
+          echo $datetime
+
+      - id: publish
+        name: Publish new version.
+        run: |
+          if [ ${{ inputs.release_candidate }} == 'true' ]
+          then
+            publish ${{ inputs.version }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin --no-cleanup --add-all
+          else
+            publish ${{ inputs.version }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin --add-all
+          fi
+        working-directory: ${{ inputs.module_directory }}
+      
+      - id: wait-for-release
+        name: Wait for release to finish.
+        continue-on-error: true
+        run: |
+          url="https://api.github.com/repos/${{ inputs.module_repository }}/actions/workflows/release.yml/runs?created=>${{ steps.current_time.outputs.datetime }}"
+          while true
+          do
+            workflows=$(curl -sS -H "Authorization: token ${{ secrets.access_token }}" $url)
+            if [ $(echo $workflows | jq '.total_count') -eq 0 ]
+            then
+              echo "Release workflow did not start"
+              sleep 60
+              continue
+            fi
+
+            release_conclusion=$(echo $workflows | jq '.workflow_runs[0].conclusion')
+            release_status=$(echo $workflows | jq '.workflow_runs[0].status')
+            if [ $release_status = \"completed\" -a $release_conclusion = \"success\" ]
+            then
+              echo "Release completed!";
+              break;
+            elif [ $release_status = \"completed\" -a $release_conclusion != \"success\" ]
+            then
+              echo "Release failed!";
+              exit 1;
+            else
+              echo $release_conclusion $release_status
+              echo "Waiting for release..."
+              sleep 60
+            fi
+          done
+      
+      - id: assets
+        name: Get plugin installable URL
+        shell: bash
+        if: steps.wait-for-release.outcome == 'success' && ${{ inputs.module_directory == 'bitergia-analytics-plugin' }}
+        run: |
+          url="https://api.github.com/repos/bitergia-analytics/bitergia-analytics-plugin/releases/tags/${{ inputs.version }}"
+          assets=$(curl -sS -H "Authorization: token ${{ secrets.ACCESS_TOKEN }}" $url)
+          plugin_url=$(echo $assets | jq '.assets[0].browser_download_url')
+          echo "plugin_url=$plugin_url" >> $GITHUB_OUTPUT
+          echo $plugin_url
+      
+      - id: rollback
+        name: Rollback last commits and remove tag
+        if: steps.wait-for-release.outcome == 'failure'
+        run: |
+          git reset --hard HEAD~1
+          git push -f origin main
+          git tag -d ${{ inputs.version }}
+          git push --delete origin ${{ inputs.version }}
+
+          # Force to fail
+          exit 1
+        working-directory: ${{ inputs.module_directory }}

--- a/.github/workflows/release-bitergia-analytics.yml
+++ b/.github/workflows/release-bitergia-analytics.yml
@@ -1,0 +1,381 @@
+name: Bitergia Analytics release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_candidate:
+        description: "Create a release candidate version"
+        required: true
+        type: boolean
+        default: false
+      git_email:
+        description: "Git email for commits messages"
+        required: true
+        default: "sduenas@bitergia.com"
+      git_name:
+        description: "Git name for commits messages"
+        required: true
+        default: "Santiago Dueñas"
+
+jobs:
+  variables-job:
+    name: Set variables
+    runs-on: ubuntu-latest
+    outputs:
+      git_email: ${{ steps.variables.outputs.git_email }}
+      git_name: ${{ steps.variables.outputs.git_name }}
+      release_candidate: ${{ steps.variables.outputs.release_candidate }}
+    steps:
+      - id: variables
+        name: variables
+        run: |
+          echo "git_email=${{ inputs.git_email }}" >> $GITHUB_OUTPUT
+          echo "git_name=${{ inputs.git_name}}" >> $GITHUB_OUTPUT
+          echo "release_candidate=${{ inputs.release_candidate}}" >> $GITHUB_OUTPUT
+
+  setup:
+    name: Get version from each repository
+    runs-on: ubuntu-latest
+    needs:
+      - variables-job
+    strategy:
+      matrix:
+        repository: [
+          bitergia-analytics,
+          bitergia-analytics-opensearch,
+          bitergia-analytics-opensearch-dashboards,
+          bitergia-analytics-plugin
+        ]
+    outputs:
+      bitergia_analytics_version: ${{ steps.semverup.outputs.bitergia-analytics }}
+      bitergia_analytics_forced_version: ${{ steps.semverup.outputs.bitergia-analytics_forced_version }}
+      opensearch_version: ${{ steps.semverup.outputs.bitergia-analytics-opensearch }}
+      opensearch_forced_version: ${{ steps.semverup.outputs.bitergia-analytics-opensearch_forced_version }}
+      dashboards_version: ${{ steps.semverup.outputs.bitergia-analytics-opensearch-dashboards }}
+      dashboards_forced_version: ${{ steps.semverup.outputs.bitergia-analytics-opensearch-dashboards_forced_version }}
+      plugin_version: ${{ steps.semverup.outputs.bitergia-analytics-plugin }}
+      plugin_forced_version: ${{ steps.semverup.outputs.bitergia-analytics-plugin_forced_version }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: bitergia-analytics/${{ matrix.repository }}
+          path: ${{ matrix.repository }}
+          token: '${{ secrets.ACCESS_TOKEN }}'
+          fetch-depth: 0
+
+      - name: Install release-tools
+        run: pip install git+https://github.com/Bitergia/release-tools.git#egg=release-tools
+      
+      - id: old-version
+        name: Get old version
+        run: |
+          if [ "${{ matrix.repository }}" == "bitergia-analytics-plugin" ]
+          then
+            version=$(jq '.version' package.json)
+          else
+            version=$(<version)
+          fi
+          echo "version=$version" >> $GITHUB_OUTPUT
+        working-directory: ${{ matrix.repository }}
+
+      - id: semverup
+        name: Get version number
+        continue-on-error: true
+        shell: bash {0}
+        run: |
+          old_version=${{ steps.old-version.outputs.version }}
+          if [ ${{ inputs.release_candidate }} == 'true' ]
+          then
+            rcArg='--pre-release'
+          else
+            rcArg=''
+          fi
+
+          version=$(semverup --dry-run --current-version $old_version $rcArg)
+          if [ -z $version ] && [ ${{ inputs.release_candidate }} != 'true' ] && [[ "$old_version" =~ .*rc.* ]]
+          then
+            echo "Create final version from rc"
+            version=$(semverup --bump-version patch)
+            forced_version=true
+          else
+            forced_version=false
+          fi
+
+          echo $version
+          echo "${{ matrix.repository }}=$version" >> $GITHUB_OUTPUT
+
+          if [ -z $version ] || [$forced_version == true]
+          then
+            echo "${{ matrix.repository }}_forced_version=true" >> $GITHUB_OUTPUT
+          else
+            echo "${{ matrix.repository }}_forced_version=false" >> $GITHUB_OUTPUT
+          fi
+        working-directory: ${{ matrix.repository }}
+   
+  semverup:
+    name: Choose highest version number
+    runs-on: ubuntu-latest
+    needs:
+      - setup
+    outputs:
+      version: ${{ steps.version.outputs.new_version }}
+    steps:
+      - name: Choose version number
+        id: version
+        run: |
+          versions=(
+            ${{ needs.setup.outputs.bitergia_analytics_version }}
+            ${{ needs.setup.outputs.plugin_version }}
+            ${{ needs.setup.outputs.opensearch_version }}
+            ${{ needs.setup.outputs.dashboards_version }}
+          )
+          IFS=$'\n' new_version=($(sort -r -V <<<"${versions[*]}" | head -n1)); unset IFS
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
+          echo $new_version
+
+  bitergia-analytics-plugin:
+    name: Bitergia Analytics Plugin
+    needs:
+      - variables-job
+      - setup
+      - semverup
+    uses: ./.github/workflows/release-bap-component.yml
+    with:
+      version: ${{ needs.semverup.outputs.version }}
+      git_email: ${{ needs.variables-job.outputs.git_email }}
+      git_name: ${{ needs.variables-job.outputs.git_name }}
+      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
+      module_name: 'bitergia-analytics-plugin'
+      module_repository: 'bitergia-analytics/bitergia-analytics-plugin'
+      module_directory: 'bitergia-analytics-plugin'
+      forced_version: ${{ needs.setup.outputs.plugin_forced_version }}
+    secrets:
+      access_token: ${{ secrets.ACCESS_TOKEN }}
+
+  bitergia-analytics-opensearch-dashboards:
+    name: Bitergia Analytics OpenSearch Dashboards
+    needs:
+      - variables-job
+      - setup
+      - semverup
+      - bitergia-analytics-plugin
+    uses: ./.github/workflows/release-bap-component.yml
+    with:
+      version: ${{ needs.semverup.outputs.version }}
+      git_email: ${{ needs.variables-job.outputs.git_email }}
+      git_name: ${{ needs.variables-job.outputs.git_name }}
+      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
+      module_name: 'bitergia-analytics-opensearch-dashboards'
+      module_repository: 'bitergia-analytics/bitergia-analytics-opensearch-dashboards'
+      module_directory: 'bitergia-analytics-opensearch-dashboards'
+      forced_version: ${{ needs.setup.outputs.dashboards_forced_version }}
+      plugin_url: ${{ needs.bitergia-analytics-plugin.outputs.plugin_url }}
+    secrets:
+      access_token: ${{ secrets.ACCESS_TOKEN }}
+    
+  bitergia-analytics-opensearch:
+    name: Bitergia Analytics OpenSearch
+    needs:
+      - variables-job
+      - setup
+      - semverup
+    uses: ./.github/workflows/release-bap-component.yml
+    with:
+      version: ${{ needs.semverup.outputs.version }}
+      git_email: ${{ needs.variables-job.outputs.git_email }}
+      git_name: ${{ needs.variables-job.outputs.git_name }}
+      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
+      module_name: 'bitergia-analytics-opensearch'
+      module_repository: 'bitergia-analytics/bitergia-analytics-opensearch'
+      module_directory: 'bitergia-analytics-opensearch'
+      forced_version: ${{ needs.setup.outputs.opensearch_forced_version }}
+    secrets:
+      access_token: ${{ secrets.ACCESS_TOKEN }}
+  
+  bitergia-analytics:
+    name: Bitergia Analytics
+    runs-on: ubuntu-latest
+    needs:
+      - variables-job
+      - setup
+      - semverup
+      - bitergia-analytics-plugin
+      - bitergia-analytics-opensearch-dashboards
+      - bitergia-analytics-opensearch
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: bitergia-analytics/bitergia-analytics
+          token: ${{ secrets.ACCESS_TOKEN }}
+          fetch-depth: 0
+      
+      - name: Set up Git config
+        run: |
+          git config --global user.email "${{ inputs.git_email }}"
+          git config --global user.name "${{ inputs.git_name }}"
+
+      - name: Install release-tools
+        run: pip install git+https://github.com/Bitergia/release-tools.git#egg=release-tools
+      
+      - id: version
+        name: Update version file
+        shell: bash
+        run: |
+          new_version=${{ needs.semverup.outputs.version }}
+          echo $new_version > version
+      
+      - name: Generate release notes
+        id: notes
+        env:
+          plugin_notes: "${{ needs.bitergia-analytics-plugin.outputs.notes }}"
+          opensearch_notes: "${{ needs.bitergia-analytics-opensearch.outputs.notes }}"
+          dashboards_notes: "${{ needs.bitergia-analytics-opensearch-dashboards.outputs.notes }}"
+        run: |
+          version=${{ needs.semverup.outputs.version }}
+          eof="EOF$(date +%s)"
+          release_file="releases/$version.md"
+          notes=''
+          if [ ${{ inputs.release_candidate }} == 'true' ]
+          then
+            newsArg=''
+            rcArg='--pre-release'
+          else
+            rcArg=''
+          fi
+
+          if [ ${{ needs.setup.outputs.bitergia_analytics_forced_version }} != true ]
+          then
+            notes "Bitergia Analytics" $version $newsArg --authors $rcArg
+            echo 'notes<<$eof' >> $GITHUB_OUTPUT
+            cat $release_file | tail -n +2 >> $GITHUB_OUTPUT
+            echo '$eof' >> $GITHUB_OUTPUT
+          else
+            echo "# Bitergia Analytics ${version}" > $release_file
+          fi
+          
+          cat << $eof >> $release_file
+          The following list describes the changes by component:
+
+          $opensearch_notes
+          $dashboards_notes
+          $plugin_notes
+          $eof
+
+          cat $release_file
+
+      - name: Generate NEWS
+        if: inputs.release_candidate == false
+        env:
+          notes_bitergia_analytics: "${{ steps.notes.outputs.notes }}"
+          notes_bitergia_analytics_plugin: "${{ needs.bitergia-analytics-plugin.outputs.notes }}"
+          notes_bitergia_analytics_opensearch: "${{ needs.bitergia-analytics-opensearch.outputs.notes }}"
+          notes_bitergia_analytics_opensearch_dashboards: "${{ needs.bitergia-analytics-opensearch-dashboards.outputs.notes }}"
+        run: |
+          version=${{ needs.semverup.outputs.version }}
+          news_file="NEWS"
+          old_news="NEWS_old"
+          new_notes="tmp_new_notes"
+          today=$(date -u "+%Y-%m-%d")
+          
+          packages=(
+          bitergia_analytics_opensearch
+          bitergia_analytics_opensearch_dashboards
+          bitergia_analytics_plugin)
+          
+          mv $news_file $old_news
+          touch $news_file $new_notes
+
+          echo "# Releases" >> $news_file
+          echo "" >> $news_file
+          echo "## Bitergia Analytics $version - ($today)" >> $news_file
+          echo "$notes_bitergia_analytics" >> $news_file
+          echo "" >> $news_file
+          for package in "${packages[@]}"
+          do
+              package_name=$(echo $package | tr '_' '-')
+              package_notes_var="notes_$package"
+              package_notes="${!package_notes_var}"
+              contents="$(echo "$package_notes" | tail -n +2)"
+              if [ ! -z "$contents" ]
+              then          
+                  echo "### $package_name" >> $new_notes
+                  echo "$contents" >> $new_notes
+                  echo "" >> $new_notes
+              fi
+          done
+          
+          echo "" >> $news_file
+          echo "The following list describes the changes by component:" >> $news_file
+          echo "" >> $news_file
+          cat $new_notes >> $news_file
+          
+          cat $old_news | tail -n +2 >> $news_file
+          
+          rm $old_news $new_notes
+          git add $news_file 
+          
+          cat $news_file
+      
+      - id: current_time
+        name: Store current time to get the release workflow
+        run: |
+          datetime=$(date +"%Y-%m-%dT%H:%M:%S%z")
+          echo "datetime=$datetime" >> $GITHUB_OUTPUT
+          echo $datetime
+
+      - id: publish
+        name: Publish new version.
+        run: |
+          if [ ${{ inputs.release_candidate }} == 'true' ]
+          then
+            publish ${{ needs.semverup.outputs.version  }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin --no-cleanup --add-all
+          else
+            publish ${{ needs.semverup.outputs.version  }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin --add-all
+          fi
+      
+      - id: wait-for-release
+        name: Wait for release to finish.
+        if: steps.publish.outcome == 'success'
+        run: |
+          url="https://api.github.com/repos/bitergia-analytics/bitergia-analytics/actions/workflows/release.yml/runs?created=>${{ steps.current_time.outputs.datetime }}"
+          while true
+          do
+            workflows=$(curl -sS -H "Authorization: token ${{ secrets.ACCESS_TOKEN }}" $url)
+            if [ $(echo $workflows | jq '.total_count') -eq 0 ]
+            then
+              echo "Release workflow did not start"
+              sleep 60
+              continue
+            fi
+
+            release_conclusion=$(echo $workflows | jq '.workflow_runs[0].conclusion')
+            release_status=$(echo $workflows | jq '.workflow_runs[0].status')
+            if [ $release_status = \"completed\" -a $release_conclusion = \"success\" ]
+            then
+              echo "Release completed!";
+              break;
+            elif [ $release_status = \"completed\" -a $release_conclusion != \"success\" ]
+            then
+              echo "Release failed!";
+              exit 1;
+            else
+              echo $release_conclusion $release_status
+              echo "Waiting for release..."
+              sleep 60
+            fi
+          done
+
+      - id: rollback
+        name: Rollback last commits and remove tag
+        if: steps.wait-for-release.outcome == 'failure'
+        run: |
+          git reset --hard HEAD~1
+          git push -f origin main
+          git tag -d ${{ needs.semverup.outputs.version }}
+          git push --delete origin ${{ needs.semverup.outputs.version }}
+
+          # Force to fail
+          exit 1
+

--- a/.github/workflows/release-bitergia-analytics.yml
+++ b/.github/workflows/release-bitergia-analytics.yml
@@ -192,7 +192,58 @@ jobs:
       forced_version: ${{ needs.setup.outputs.opensearch_forced_version }}
     secrets:
       access_token: ${{ secrets.ACCESS_TOKEN }}
-  
+
+  perceval-public-inbox:
+    name: perceval-public-inbox
+    needs:
+      - variables-job
+      - setup
+      - semverup
+    uses: ./.github/workflows/release-grimoirelab-component.yml
+    with:
+      git_email: ${{ needs.variables-job.outputs.git_email }}
+      git_name: ${{ needs.variables-job.outputs.git_name }}
+      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
+      module_name: 'perceval-public-inbox'
+      module_repository: 'bitergia-analytics/grimoirelab-perceval-public-inbox'
+      module_directory: 'perceval-public-inbox'
+    secrets:
+      access_token: ${{ secrets.ACCESS_TOKEN }}
+
+  elk-public-inbox:
+    name: elk-public-inbox
+    needs:
+      - variables-job
+      - setup
+      - semverup
+    uses: ./.github/workflows/release-grimoirelab-component.yml
+    with:
+      git_email: ${{ needs.variables-job.outputs.git_email }}
+      git_name: ${{ needs.variables-job.outputs.git_name }}
+      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
+      module_name: 'elk-public-inbox'
+      module_repository: 'bitergia-analytics/grimoirelab-elk-public-inbox'
+      module_directory: 'elk-public-inbox'
+    secrets:
+      access_token: ${{ secrets.ACCESS_TOKEN }}
+
+  sortinghat-openinfra:
+    name: sortinghat-openinfra
+    needs:
+      - variables-job
+      - setup
+      - semverup
+    uses: ./.github/workflows/release-grimoirelab-component.yml
+    with:
+      git_email: ${{ needs.variables-job.outputs.git_email }}
+      git_name: ${{ needs.variables-job.outputs.git_name }}
+      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
+      module_name: 'sortinghat-openinfra'
+      module_repository: 'bitergia-analytics/sortinghat-openinfra'
+      module_directory: 'sortinghat-openinfra'
+    secrets:
+      access_token: ${{ secrets.ACCESS_TOKEN }}
+
   bitergia-analytics:
     name: Bitergia Analytics
     runs-on: ubuntu-latest
@@ -203,6 +254,9 @@ jobs:
       - bitergia-analytics-plugin
       - bitergia-analytics-opensearch-dashboards
       - bitergia-analytics-opensearch
+      - perceval-public-inbox
+      - elk-public-inbox
+      - sortinghat-openinfra
     steps:
       - name: Checkout source code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -232,6 +286,9 @@ jobs:
           plugin_notes: "${{ needs.bitergia-analytics-plugin.outputs.notes }}"
           opensearch_notes: "${{ needs.bitergia-analytics-opensearch.outputs.notes }}"
           dashboards_notes: "${{ needs.bitergia-analytics-opensearch-dashboards.outputs.notes }}"
+          perceval_public_inbox_notes: "${{ needs.perceval-public-inbox.outputs.notes }}"
+          elk_public_inbox_notes: "${{ needs.elk-public-inbox.outputs.notes }}"
+          sortinghat_openinfra_notes: "${{ needs.sortinghat-openinfra.outputs.notes }}"
         run: |
           version=${{ needs.semverup.outputs.version }}
           eof="EOF$(date +%s)"
@@ -261,6 +318,9 @@ jobs:
           $opensearch_notes
           $dashboards_notes
           $plugin_notes
+          $perceval_public_inbox_notes
+          $elk_public_inbox_notes
+          $sortinghat_openinfra_notes
           $eof
 
           cat $release_file
@@ -272,6 +332,9 @@ jobs:
           notes_bitergia_analytics_plugin: "${{ needs.bitergia-analytics-plugin.outputs.notes }}"
           notes_bitergia_analytics_opensearch: "${{ needs.bitergia-analytics-opensearch.outputs.notes }}"
           notes_bitergia_analytics_opensearch_dashboards: "${{ needs.bitergia-analytics-opensearch-dashboards.outputs.notes }}"
+          notes_perceval_public_inbox: "${{ needs.perceval-public-inbox.outputs.notes }}"
+          notes_elk_public_inbox: "${{ needs.elk-public-inbox.outputs.notes }}"
+          notes_sortinghat_openinfra: "${{ needs.sortinghat-openinfra.outputs.notes }}"
         run: |
           version=${{ needs.semverup.outputs.version }}
           news_file="NEWS"
@@ -282,7 +345,10 @@ jobs:
           packages=(
           bitergia_analytics_opensearch
           bitergia_analytics_opensearch_dashboards
-          bitergia_analytics_plugin)
+          bitergia_analytics_plugin
+          perceval_public_inbox
+          elk_public_inbox
+          sortinghat_openinfra)
           
           mv $news_file $old_news
           touch $news_file $new_notes
@@ -378,5 +444,4 @@ jobs:
 
           # Force to fail
           exit 1
-
 

--- a/.github/workflows/release-bitergia-analytics.yml
+++ b/.github/workflows/release-bitergia-analytics.yml
@@ -379,3 +379,4 @@ jobs:
           # Force to fail
           exit 1
 
+

--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -1,0 +1,270 @@
+name: Release GrimoireLab component
+
+on:
+  workflow_call:
+    inputs:
+      git_email:
+        description: 'Git config email'
+        type: string
+        required: true
+      git_name:
+        description: 'Git config name'
+        type: string
+        required: true
+      release_candidate:
+        description: 'Create a release candidate version'
+        type: string
+        required: true
+      module_name:
+        description: 'Name of the module'
+        type: string
+        required: true
+      module_repository:
+        description: 'Repository of the module'
+        type: string
+        required: true
+      module_directory:
+        description: 'Location of the module'
+        type: string
+        required: true
+    secrets:
+      access_token:
+        description: 'Token for updating repositories'
+        required: true
+
+    outputs:
+      package_version:
+        description: "Package version formatted for Poetry"
+        value: ${{ jobs.release.outputs.package_version }}
+      version:
+        description: "Version number for the package"
+        value: ${{ jobs.release.outputs.version }}
+      notes:
+        description: "Notes content for the package"
+        value: ${{ jobs.release.outputs.notes }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      package_version: ${{ steps.version.outputs.package_version }}
+      notes: ${{ steps.notes.outputs.notes }}
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: ${{ inputs.module_repository }}
+          path: ${{ inputs.module_directory }}
+          token: '${{ secrets.access_token }}'
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
+        with:
+          python-version: 3.8
+
+      - name: Set up Git config
+        run: |
+          git config --global user.email "${{ inputs.git_email }}"
+          git config --global user.name "${{ inputs.git_name }}"
+
+
+      - name: Install poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Install release-tools
+        #TODO: Change to the latest version once the new release is created
+        run: pip install git+https://github.com/Bitergia/release-tools.git#egg=release-tools
+
+      - id: old-version
+        name: Get old version
+        run: |
+          version=$(poetry version -s)
+          echo "version=$version" >> $GITHUB_OUTPUT
+        working-directory: ${{ inputs.module_directory }}
+
+      - id: semverup
+        name: Update version number
+        continue-on-error: true
+        shell: bash {0}
+        run: |
+          if [ ${{ inputs.release_candidate }} == 'true' ]
+          then
+            rcArg='--pre-release'
+          else
+            rcArg=''
+          fi
+          old_version=${{ steps.old-version.outputs.version }}
+
+          version=$(semverup $rcArg)
+          if [ -z $version ] && [ ${{ inputs.release_candidate }} != 'true' ] && [[ "$old_version" =~ .*rc.* ]]
+          then
+            echo "Create final version from rc"
+            version=$(semverup --bump-version patch)
+            echo "forced_version=true" >> $GITHUB_OUTPUT
+          else
+            echo "forced_version=false" >> $GITHUB_OUTPUT
+          fi
+          echo $version
+          if [ -z $version ]; then exit 1; fi
+        working-directory: ${{ inputs.module_directory }}
+
+      - id: version
+        name: Get current version
+        run: |
+          version=$(poetry version -s)
+          package_version="${{ inputs.module_name }}@>=$version"
+          echo "package_version=$package_version" >> $GITHUB_OUTPUT
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo $package_version
+        working-directory: ${{ inputs.module_directory }}
+
+      - id: notes
+        name: Generate release notes.
+        if: steps.semverup.outcome == 'success'
+        run: |
+          version=${{ steps.version.outputs.version }}
+          eof="EOF$(date +%s)"
+          release_file="releases/$version.md"
+          if [ ${{ inputs.release_candidate }} == 'true' ]
+          then
+            newsArg=''
+            rcArg='--pre-release'
+          else
+            newsArg='--news'
+            rcArg=''
+          fi
+          
+          if [ ${{ steps.semverup.outputs.forced_version }} != 'true' ]
+          then
+            notes "${{ inputs.module_name }}" $version $newsArg --authors $rcArg
+          else
+            module_name=${{ inputs.module_name }}
+            today=$(date -u "+%Y-%m-%d")
+            cat << EOF > $release_file
+            ## $module_name $version - ($today)
+            
+            * Update Poetry's package dependencies
+          EOF
+            # Update NEWS file if it is not a release candidate
+            if [ ${{ inputs.release_candidate }} != 'true' ]
+            then
+              mv NEWS old_NEWS
+              echo -e "# Releases\n" >> NEWS
+              cat $release_file >> NEWS
+              cat old_NEWS | tail -n +2 >> NEWS
+            fi
+          fi
+
+          # Save release notes in 'notes' output
+          echo 'notes<<$eof' >> $GITHUB_OUTPUT
+          cat $release_file >> $GITHUB_OUTPUT
+          echo '$eof' >> $GITHUB_OUTPUT
+        working-directory: ${{ inputs.module_directory }}
+
+      - id: current_time
+        name: Store current time to get the release workflow
+        if: steps.semverup.outcome == 'success'
+        run: |
+          datetime=$(date +"%Y-%m-%dT%H:%M:%S%z")
+          echo "datetime=$datetime" >> $GITHUB_OUTPUT
+          echo $datetime
+
+      - id: publish
+        name: Publish new version.
+        if: steps.semverup.outcome == 'success'
+        run: |
+          if [ ${{ inputs.release_candidate }} == 'true' ]
+          then
+            publish ${{ steps.version.outputs.version }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin --no-cleanup
+          else
+            publish ${{ steps.version.outputs.version }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin
+          fi
+        working-directory: ${{ inputs.module_directory }}
+
+      - id: wait-for-release
+        name: Wait for release to finish.
+        continue-on-error: true
+        if: steps.publish.outcome == 'success'
+        run: |
+          url="https://api.github.com/repos/${{ inputs.module_repository }}/actions/workflows/release.yml/runs?created=>${{ steps.current_time.outputs.datetime }}"
+          while true
+          do
+            workflows=$(curl -sS -H "Authorization: token ${{ secrets.access_token }}" $url)
+            if [ $(echo $workflows | jq '.total_count') -eq 0 ]
+            then
+              echo "Release workflow did not start"
+              sleep 60
+              continue
+            fi
+
+            release_conclusion=$(echo $workflows | jq '.workflow_runs[0].conclusion')
+            release_status=$(echo $workflows | jq '.workflow_runs[0].status')
+            if [ $release_status = \"completed\" -a $release_conclusion = \"success\" ]
+            then
+              echo "Release completed!";
+              break;
+            elif [ $release_status = \"completed\" -a $release_conclusion != \"success\" ]
+            then
+              echo "Release failed!";
+              exit 1;
+            else
+              echo $release_conclusion $release_status
+              echo "Waiting for release..."
+              sleep 60
+            fi
+          done
+
+      - id: check-package-ready
+        name: Wait for package ready in PyPI
+        shell: bash
+        if: steps.wait-for-release.outcome == 'success'
+        run: |
+          package="${{ inputs.module_name }}"
+          version="${{ steps.version.outputs.version }}"
+          # Format version 1.2.3-rc.1 to 1.2.3rc1
+          versionNum=${version%-*}
+          versionRC=${version#$versionNum}
+          versionRC=${versionRC//[-.]/}
+          currentVersion="${versionNum}${versionRC}"
+
+          pip install --upgrade pip
+          for i in $(seq 20)
+          do
+            pip index versions --pre $package > pip_versions.txt
+            pipVersion=$(cat pip_versions.txt | head -n 1 | cut -f2 -d '(' | cut -f1 -d ')')
+            echo "$currentVersion $pipVersion"
+            if [ "$pipVersion" = "$currentVersion" ]
+            then
+              echo "Same version"
+              exit 0
+            fi
+            echo "Wait for PyPI..."
+            sleep 10
+          done
+          echo "Latest version doesn't match after several retries"
+          exit 1
+
+      - id: rollback
+        name: Rollback last commit and remove tag
+        if: steps.wait-for-release.outcome == 'failure'
+        run: |
+          dep_updated=${{ steps.update-dependencies.outputs.dep_updated }}
+          if [ $dep_updated -gt 0 ]
+          then
+            git reset --hard HEAD~2
+          else
+            git reset --hard HEAD~1
+          fi
+          git push -f origin main
+          git tag -d ${{ steps.version.outputs.version }}
+          git push --delete origin ${{ steps.version.outputs.version }}
+
+          # Force to fail
+          exit 1
+        working-directory: ${{ inputs.module_directory }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+      - '*.*.*-*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create a new release on the repository
+        uses: chaoss/grimoirelab-github-actions/release@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+Santiago Dueñas <sduenas@bitergia.com>
+Jose Javier Merchante <jjmerchante@bitergia.com>

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,1 @@
+# Releases


### PR DESCRIPTION
This PR adds the `release-bitergia-analytics` GitHub workflow to automate the release of Bitergia Analytics and its components. It must be triggered manually and requires an `ACCESS_TOKEN` secret in the repository.

The workflow uses `release-tools` to increment the version number in all components (bitergia-analytics, bitergia-analytics-opensearch, bitergia-analytics-opensearch-dashboards and bitergia-analytics-plugin) according to their release notes and then uses the highest version number for the release. It changes the version number in all the needed files, updates the plugin URL that is installed in bitergia-analytics-opensearch-dashboards, generates the release notes and publishes the changes with the version tag in all four repositories. The `release` workflow is then triggered by the new tag.