### PR TITLE
[release] Rename elk package name

### DIFF
--- a/.github/workflows/release-bitergia-analytics.yml
+++ b/.github/workflows/release-bitergia-analytics.yml
@@ -223,7 +223,7 @@ jobs:
       git_email: ${{ needs.variables-job.outputs.git_email }}
       git_name: ${{ needs.variables-job.outputs.git_name }}
       release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
-      module_name: 'elk-public-inbox'
+      module_name: 'grimoire-elk-public-inbox'
       module_repository: 'bitergia-analytics/grimoirelab-elk-public-inbox'
       module_directory: 'elk-public-inbox'
       dependencies: "${{ needs.perceval-public-inbox.outputs.package_version }}"


### PR DESCRIPTION
This PR replaces the name of the ELK package to be `grimoire-elk-public-inbox` instead of `elk-public-inbox`. This was causing the workflow to fail because that package did not exist.