### PR TITLE
[release] Fix bash condition in the release

### DIFF
--- a/.github/workflows/release-bitergia-analytics.yml
+++ b/.github/workflows/release-bitergia-analytics.yml
@@ -106,7 +106,7 @@ jobs:
           echo $version
           echo "${{ matrix.repository }}=$version" >> $GITHUB_OUTPUT
 
-          if [ -z $version ] || [$forced_version == true]
+          if [ -z $version ] || [ $forced_version == true ]
           then
             echo "${{ matrix.repository }}_forced_version=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
This PR fixes a typo in the GitHub action. There is a missing space between the test command (`[`) and the variable.