### PR TITLE
Bump GrimoireLab to 0.16.0

### DIFF
--- a/docker-sortinghat/server.dockerfile
+++ b/docker-sortinghat/server.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat:0.15.1
+FROM grimoirelab/sortinghat:0.16.0
 
 ADD settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings.py
 

--- a/docker-sortinghat/worker.dockerfile
+++ b/docker-sortinghat/worker.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat-worker:0.15.1
+FROM grimoirelab/sortinghat-worker:0.16.0
 
 ADD settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings.py
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM grimoirelab/grimoirelab:0.15.1
+FROM grimoirelab/grimoirelab:0.16.0
 
 LABEL org.opencontainers.image.title="Bitergia Analytics"
 LABEL org.opencontainers.image.description="Bitergia Analytics service"

--- a/releases/unreleased/grimoirelab-version-updated-to-0160.yml
+++ b/releases/unreleased/grimoirelab-version-updated-to-0160.yml
@@ -1,0 +1,14 @@
+---
+title: GrimoireLab version updated to 0.16.0
+category: added
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  This version of GrimoireLab generally improves
+  the performance of the identities manager. Now,
+  individuals data will be loaded in the user
+  interface much faster; recommendations will be
+  generated for those identities updated after
+  a giving date only, and the users will be able
+  to add individuals to the workspace from the
+  individual profile page.


### PR DESCRIPTION
This commit updates the version of GrimoireLab to 0.16.0.