### PR TITLE
Upgrade to GrimoireLab 0.19.0

### DIFF
--- a/docker-sortinghat/server.dockerfile
+++ b/docker-sortinghat/server.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat:0.18.0
+FROM grimoirelab/sortinghat:0.19.0
 
 ADD settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings.py
 

--- a/docker-sortinghat/worker.dockerfile
+++ b/docker-sortinghat/worker.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat-worker:0.18.0
+FROM grimoirelab/sortinghat-worker:0.19.0
 
 ADD settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings.py
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM grimoirelab/grimoirelab:0.18.0
+FROM grimoirelab/grimoirelab:0.19.0
 
 LABEL org.opencontainers.image.title="Bitergia Analytics"
 LABEL org.opencontainers.image.description="Bitergia Analytics service"

--- a/releases/unreleased/grimoirelab-0190.yml
+++ b/releases/unreleased/grimoirelab-0190.yml
@@ -1,0 +1,9 @@
+---
+title: GrimoireLab 0.19.0
+category: dependency
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  This version of GrimoireLab improves the performance
+  generating affiliations for identities plus improves
+  the user experience on the identities manager.


### PR DESCRIPTION
This commit updates BAP to use GrimoireLab 0.19.0.