### PR TITLE
Upgrade to GrimoireLab 0.20.2

### DIFF
--- a/docker-sortinghat/server.dockerfile
+++ b/docker-sortinghat/server.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat:0.20.1
+FROM grimoirelab/sortinghat:0.20.2
 
 ADD settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings.py
 

--- a/docker-sortinghat/worker.dockerfile
+++ b/docker-sortinghat/worker.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat-worker:0.20.1
+FROM grimoirelab/sortinghat-worker:0.20.2
 
 ADD settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings.py
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM grimoirelab/grimoirelab:0.20.1
+FROM grimoirelab/grimoirelab:0.20.2
 
 LABEL org.opencontainers.image.title="Bitergia Analytics"
 LABEL org.opencontainers.image.description="Bitergia Analytics service"

--- a/releases/unreleased/upgrade-to-grimoirelab-0202.yml
+++ b/releases/unreleased/upgrade-to-grimoirelab-0202.yml
@@ -1,0 +1,7 @@
+---
+title: GrimoireLab 0.20.2 upgrade
+category: dependency
+author: null
+issue: null
+notes: >
+  Bug fixing release.


### PR DESCRIPTION
This commit updates the platform to use GrimoireLab 0.20.2. This release only fixes some bugs.