### PR TITLE
Upgrade to GrimoireLab 0.21.0

### DIFF
--- a/docker-sortinghat/server.dockerfile
+++ b/docker-sortinghat/server.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat:0.20.2
+FROM grimoirelab/sortinghat:0.21.0
 
 ADD settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings.py
 

--- a/docker-sortinghat/worker.dockerfile
+++ b/docker-sortinghat/worker.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat-worker:0.20.2
+FROM grimoirelab/sortinghat-worker:0.21.0
 
 ADD settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings.py
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM grimoirelab/grimoirelab:0.20.2
+FROM grimoirelab/grimoirelab:0.21.0
 
 LABEL org.opencontainers.image.title="Bitergia Analytics"
 LABEL org.opencontainers.image.description="Bitergia Analytics service"

--- a/releases/unreleased/grimoirelab-0210-upgrade.yml
+++ b/releases/unreleased/grimoirelab-0210-upgrade.yml
@@ -1,0 +1,8 @@
+---
+title: GrimoireLab 0.21.0 upgrade
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: |
+  This new version of GrimoireLab includes organization
+  aliases in SortingHat to avoid duplicates.


### PR DESCRIPTION
This PR updates the platform to use GrimoireLab 0.21.0. This release includes organization aliases in SortingHat to avoid duplicates.