### PR TITLE
Upgrade to GrimoireLab 0.22.0

### DIFF
--- a/docker-sortinghat/server.dockerfile
+++ b/docker-sortinghat/server.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat:0.21.0
+FROM grimoirelab/sortinghat:0.22.0
 
 ADD settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings.py
 

--- a/docker-sortinghat/worker.dockerfile
+++ b/docker-sortinghat/worker.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat-worker:0.21.0
+FROM grimoirelab/sortinghat-worker:0.22.0
 
 ADD settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings.py
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM grimoirelab/grimoirelab:0.21.0
+FROM grimoirelab/grimoirelab:0.22.0
 
 LABEL org.opencontainers.image.title="Bitergia Analytics"
 LABEL org.opencontainers.image.description="Bitergia Analytics service"

--- a/releases/unreleased/grimoirelab-0220-upgrade.yml
+++ b/releases/unreleased/grimoirelab-0220-upgrade.yml
@@ -1,0 +1,10 @@
+---
+title: GrimoireLab 0.22.0 upgrade
+category: added
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  On this release, GrimoireLab allows to define
+  dedicated queues for SortingHat jobs. Also,
+  SortingHat runs with Node 20, dropping the support
+  of versions 14-16.


### PR DESCRIPTION
This commit updates the platform to use GrimoireLab 0.22.0. The new release incorporates the definition of dedicated queues for the SortingHat jobs.