### PR TITLE
Upgrade to GrimoireLab 1.4.1

### DIFF
--- a/docker-sortinghat/server.dockerfile
+++ b/docker-sortinghat/server.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat:1.4.0
+FROM grimoirelab/sortinghat:1.4.1
 
 COPY settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings_bap.py
 

--- a/docker-sortinghat/worker.dockerfile
+++ b/docker-sortinghat/worker.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat-worker:1.4.0
+FROM grimoirelab/sortinghat-worker:1.4.1
 
 COPY settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings_bap.py
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM grimoirelab/grimoirelab:1.4.0
+FROM grimoirelab/grimoirelab:1.4.1
 
 LABEL org.opencontainers.image.title="Bitergia Analytics"
 LABEL org.opencontainers.image.description="Bitergia Analytics service"

--- a/releases/unreleased/update-grimoirelab-to-141.yml
+++ b/releases/unreleased/update-grimoirelab-to-141.yml
@@ -1,0 +1,10 @@
+---
+title: Upgrade GrimoireLab to 1.4.1
+category: fixed
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  GrimoireLab 1.4.1 fixes an important bug when enritching
+  indenties data. The previous version crashed the service
+  enritching data of datasources such as GitLab, Slack,
+  or StackExchange.


### PR DESCRIPTION
Bump GrimoireLab to version 1.4.1 to fix a bug enritching identities of datasources such GitLab, Slack, or StackExchange.