### PR TITLE
Fix SortingHat settings path

### DIFF
--- a/docker-sortinghat/server.dockerfile
+++ b/docker-sortinghat/server.dockerfile
@@ -1,6 +1,6 @@
 FROM grimoirelab/sortinghat:1.5.0
 
-COPY settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings_bap.py
+COPY settings.py /opt/venv/lib/python3.8/site-packages/sortinghat/config/settings_bap.py
 
 RUN . /opt/venv/bin/activate && \
     pip install sortinghat-openinfra

--- a/docker-sortinghat/worker.dockerfile
+++ b/docker-sortinghat/worker.dockerfile
@@ -1,6 +1,6 @@
 FROM grimoirelab/sortinghat-worker:1.5.0
 
-COPY settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings_bap.py
+COPY settings.py /opt/venv/lib/python3.8/site-packages/sortinghat/config/settings_bap.py
 
 RUN . /opt/venv/bin/activate && \
     pip install sortinghat-openinfra

--- a/releases/unreleased/sortinghat-settings-wrong-path.yml
+++ b/releases/unreleased/sortinghat-settings-wrong-path.yml
@@ -1,0 +1,9 @@
+---
+title: SortingHat settings wrong path
+category: fixed
+author: null
+issue: null
+notes: >
+  SortingHat is now using a different version of Python,
+  and the settings were imported to the wrong path.
+  The path has now been corrected.


### PR DESCRIPTION
This PR updates the path where the settings are copied. Due to the switch to a different Python version, the path has changed.