### PR TITLE
Upgrade Python version to 3.9

### DIFF
--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -65,10 +65,10 @@ jobs:
           path: ${{ inputs.module_directory }}
           token: '${{ secrets.access_token }}'
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Set up Git config
         run: |

--- a/docker-sortinghat/server.dockerfile
+++ b/docker-sortinghat/server.dockerfile
@@ -1,6 +1,6 @@
 FROM grimoirelab/sortinghat:1.5.0
 
-COPY settings.py /opt/venv/lib/python3.8/site-packages/sortinghat/config/settings_bap.py
+COPY settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings_bap.py
 
 RUN . /opt/venv/bin/activate && \
     pip install sortinghat-openinfra

--- a/docker-sortinghat/worker.dockerfile
+++ b/docker-sortinghat/worker.dockerfile
@@ -1,6 +1,6 @@
 FROM grimoirelab/sortinghat-worker:1.5.0
 
-COPY settings.py /opt/venv/lib/python3.8/site-packages/sortinghat/config/settings_bap.py
+COPY settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings_bap.py
 
 RUN . /opt/venv/bin/activate && \
     pip install sortinghat-openinfra

--- a/releases/unreleased/python-minimum-version-updated.yml
+++ b/releases/unreleased/python-minimum-version-updated.yml
@@ -1,0 +1,8 @@
+---
+title: Python version updated to 3.9
+category: dependency
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Python 3.8 will reach its end of life in October 2024.
+  Python 3.9 is the minimum version required by the project.


### PR DESCRIPTION
Python 3.8 will reach its end of life in October 2024, and Python 3.9 will become the minimum version required by the project.