### PR TITLE
[sh] Include OpenInfra as trusted source for matching

### DIFF
--- a/docker-sortinghat/settings.py
+++ b/docker-sortinghat/settings.py
@@ -14,3 +14,10 @@ from sortinghat.config.settings import *  # noqa: F403,F401
 
 OPENINFRA_CLIENT_ID = os.environ.get('SORTINGHAT_OPENINFRA_CLIENT_ID', None)
 OPENINFRA_CLIENT_SECRET = os.environ.get('SORTINGHAT_OPENINFRA_CLIENT_SECRET', None)
+
+#
+# Trusted data sources for matching by username
+#
+
+MATCH_TRUSTED_SOURCES = os.environ.get('SORTINGHAT_MATCH_TRUSTED_SOURCES',
+                                       'github,gitlab,slack,openinfra').split(',')

--- a/releases/unreleased/openinfra-trusted-source-for-matching.yml
+++ b/releases/unreleased/openinfra-trusted-source-for-matching.yml
@@ -1,0 +1,8 @@
+---
+title: Openinfra trusted source for matching
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Include Openinfra backend as a trusted source
+  for matching by username by default.


### PR DESCRIPTION
This PR includes the 'openinfra' backend as a trusted source by default when doing matching my username.