### PR TITLE
Upgrade to GrimoireLab 1.7.0

### DIFF
--- a/docker-sortinghat/server.dockerfile
+++ b/docker-sortinghat/server.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat:1.6.0
+FROM grimoirelab/sortinghat:1.7.0
 
 COPY settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings_bap.py
 

--- a/docker-sortinghat/worker.dockerfile
+++ b/docker-sortinghat/worker.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat-worker:1.6.0
+FROM grimoirelab/sortinghat-worker:1.7.0
 
 COPY settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings_bap.py
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM grimoirelab/grimoirelab:1.6.0
+FROM grimoirelab/grimoirelab:1.7.0
 
 LABEL org.opencontainers.image.title="Bitergia Analytics"
 LABEL org.opencontainers.image.description="Bitergia Analytics service"

--- a/releases/unreleased/upgrade-to-grimoirelab-170.yml
+++ b/releases/unreleased/upgrade-to-grimoirelab-170.yml
@@ -1,0 +1,11 @@
+---
+title: Upgrade to GrimoireLab 1.7.0
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  GrimoireLab 1.7.0 improves SortingHat adding individual
+  review system and several fixes. Grimoire-Elk 1.3.0 adds
+  keywords and response times for Bugzilla, and resolves
+  a bug in the reference analysis studio.
+  See GrimoireLab release notes for more information.


### PR DESCRIPTION
Bumps GrimoireLab to 1.7.0 version.