### PR TITLE
Migrate files for branch rename from master to main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,4 +10,4 @@ jobs:
   check-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: bitergia/release-tools-check-changelog@master
+      - uses: bitergia/release-tools-check-changelog@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create a new release on the repository
-        uses: chaoss/grimoirelab-github-actions/release@master
+        uses: chaoss/grimoirelab-github-actions/release@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,7 +20,7 @@ GrimoireLab, including all libraries and programs.
 The image will run the GrimoireLab orchestrator - sirmordred - by default. This
 needs a `setup.cfg` and a `projects.json` file. You can find more
 information about how to define these two files either on the
-[GrimoireLab](https://github.com/chaoss/grimoirelab/tree/master/docker) or
+[GrimoireLab](https://github.com/chaoss/grimoirelab/tree/main/docker) or
 [Sir Mordred](https://github.com/chaoss/grimoirelab-sirmordred) repositories
 
 You will also need the Bitergia Analytics Opensearch, Opensearch Dashboards, and


### PR DESCRIPTION
Update files to support the migration of GrimoireLab repositories as part of the default branch transition from master to main.