### PR TITLE
Upgrade to GrimorieLab 1.9.2

### DIFF
--- a/docker-sortinghat/server.dockerfile
+++ b/docker-sortinghat/server.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat:1.9.0
+FROM grimoirelab/sortinghat:1.9.2
 
 COPY settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings_bap.py
 

--- a/docker-sortinghat/worker.dockerfile
+++ b/docker-sortinghat/worker.dockerfile
@@ -1,4 +1,4 @@
-FROM grimoirelab/sortinghat-worker:1.9.0
+FROM grimoirelab/sortinghat-worker:1.9.2
 
 COPY settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings_bap.py
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM grimoirelab/grimoirelab:1.9.0
+FROM grimoirelab/grimoirelab:1.9.2
 
 LABEL org.opencontainers.image.title="Bitergia Analytics"
 LABEL org.opencontainers.image.description="Bitergia Analytics service"

--- a/releases/unreleased/upgrade-to-grimoirelab-192.yml
+++ b/releases/unreleased/upgrade-to-grimoirelab-192.yml
@@ -1,0 +1,8 @@
+---
+title: Upgrade to GrimoireLab 1.9.2
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  GrimoireLab 1.9.2 updates the packages.
+  See GrimoireLab release notes for more information.


### PR DESCRIPTION
Bumps GrimoireLab to 1.9.2 version.