### PR TITLE
SortingHat image updated to use Python 3.12

### DIFF
--- a/docker-sortinghat/server.dockerfile
+++ b/docker-sortinghat/server.dockerfile
@@ -1,6 +1,6 @@
 FROM grimoirelab/sortinghat:1.14.1
 
-COPY settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings_bap.py
+COPY settings.py /opt/venv/lib/python3.12/site-packages/sortinghat/config/settings_bap.py
 
 RUN . /opt/venv/bin/activate && \
     pip install sortinghat-openinfra

--- a/docker-sortinghat/worker.dockerfile
+++ b/docker-sortinghat/worker.dockerfile
@@ -1,6 +1,6 @@
 FROM grimoirelab/sortinghat-worker:1.14.1
 
-COPY settings.py /opt/venv/lib/python3.9/site-packages/sortinghat/config/settings_bap.py
+COPY settings.py /opt/venv/lib/python3.12/site-packages/sortinghat/config/settings_bap.py
 
 RUN . /opt/venv/bin/activate && \
     pip install sortinghat-openinfra

--- a/releases/unreleased/sortinghat-image-updated-to-use-python-312.yml
+++ b/releases/unreleased/sortinghat-image-updated-to-use-python-312.yml
@@ -1,0 +1,8 @@
+---
+title: SortingHat image updated to use Python 3.12
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Update the BAP SortingHat image to use Python 3.12 when
+  copying the bap settings.


### PR DESCRIPTION
Update the SortingHat image to use Python 3.12 when copying the `bap_settings` file.