### PR TITLE
Add SortingHat Eclipse identities importer

### DIFF
--- a/.github/workflows/release-bitergia-analytics.yml
+++ b/.github/workflows/release-bitergia-analytics.yml
@@ -385,6 +385,23 @@ jobs:
     secrets:
       access_token: ${{ secrets.BAP_BUILD_TOKEN }}
 
+  sortinghat-eclipse-foundation:
+    name: sortinghat-eclipse-foundation
+    needs:
+      - variables-job
+      - setup
+      - semverup
+    uses: ./.github/workflows/release-grimoirelab-component.yml
+    with:
+      git_email: ${{ needs.variables-job.outputs.git_email }}
+      git_name: ${{ needs.variables-job.outputs.git_name }}
+      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
+      module_name: 'sortinghat-eclipse-foundation'
+      module_repository: 'bitergia-analytics/sortinghat-eclipse-foundation'
+      module_directory: 'sortinghat-eclipse-foundation'
+    secrets:
+      access_token: ${{ secrets.BAP_BUILD_TOKEN }}
+
   bitergia-analytics:
     name: Bitergia Analytics
     runs-on: ubuntu-latest
@@ -405,6 +422,7 @@ jobs:
       - perceval-pontoon
       - bap-elk-backends
       - sortinghat-openinfra
+      - sortinghat-eclipse-foundation
     steps:
       - name: Checkout source code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -443,6 +461,7 @@ jobs:
           perceval_pontoon_notes: "${{ needs.perceval-pontoon.outputs.notes }}"
           bap_elk_backends_notes: "${{ needs.bap-elk-backends.outputs.notes }}"
           sortinghat_openinfra_notes: "${{ needs.sortinghat-openinfra.outputs.notes }}"
+          sortinghat_eclipse_foundation_notes: "${{ needs.sortinghat-eclipse-foundation.outputs.notes }}"
         run: |
           version=${{ needs.semverup.outputs.version }}
           eof="EOF$(date +%s)"
@@ -481,6 +500,7 @@ jobs:
           $perceval_pontoon_notes
           $bap_elk_backends_notes
           $sortinghat_openinfra_notes
+          $sortinghat_eclipse_foundation_notes
           $eof
 
           cat $release_file
@@ -501,6 +521,7 @@ jobs:
           notes_perceval_pontoon: "${{ needs.perceval-pontoon.outputs.notes }}"
           notes_bap_elk_backends: "${{ needs.bap-elk-backends.outputs.notes }}"
           notes_sortinghat_openinfra: "${{ needs.sortinghat-openinfra.outputs.notes }}"
+          notes_sortinghat_eclipse_foundation: "${{ needs.sortinghat-eclipse-foundation.outputs.notes }}"
         run: |
           version=${{ needs.semverup.outputs.version }}
           news_file="NEWS"
@@ -520,7 +541,8 @@ jobs:
           perceval_topicbox
           perceval_pontoon
           notes_bap_elk_backends
-          sortinghat_openinfra)
+          sortinghat_openinfra
+          sortinghat_eclipse_foundation)
           
           mv $news_file $old_news
           touch $news_file $new_notes

--- a/docker-sortinghat/server.dockerfile
+++ b/docker-sortinghat/server.dockerfile
@@ -3,4 +3,5 @@ FROM grimoirelab/sortinghat:1.15.1
 COPY settings.py /opt/venv/lib/python3.12/site-packages/sortinghat/config/settings_bap.py
 
 RUN . /opt/venv/bin/activate && \
-    pip install sortinghat-openinfra
+    pip install sortinghat-openinfra && \
+    pip install sortinghat-eclipse-foundation

--- a/docker-sortinghat/settings.py
+++ b/docker-sortinghat/settings.py
@@ -16,6 +16,13 @@ OPENINFRA_CLIENT_ID = os.environ.get('SORTINGHAT_OPENINFRA_CLIENT_ID', None)
 OPENINFRA_CLIENT_SECRET = os.environ.get('SORTINGHAT_OPENINFRA_CLIENT_SECRET', None)
 
 #
+# Eclipse Foundation keys
+#
+
+ECLIPSE_FOUNDATION_USER_ID = os.environ.get('SORTINGHAT_ECLIPSE_FOUNDATION_USER_ID', None)
+ECLIPSE_FOUNDATION_PASSWORD = os.environ.get('SORTINGHAT_ECLIPSE_FOUNDATION_PASSWORD', None)
+
+#
 # Trusted data sources for matching by username
 #
 

--- a/docker-sortinghat/worker.dockerfile
+++ b/docker-sortinghat/worker.dockerfile
@@ -3,7 +3,9 @@ FROM grimoirelab/sortinghat-worker:1.15.1
 COPY settings.py /opt/venv/lib/python3.12/site-packages/sortinghat/config/settings_bap.py
 
 RUN . /opt/venv/bin/activate && \
-    pip install sortinghat-openinfra
+    pip install sortinghat-openinfra && \
+    pip install sortinghat-eclipse-foundation
+
 
 USER root
 

--- a/releases/unreleased/sortinghat-eclipse-foundation-identities-importer.yml
+++ b/releases/unreleased/sortinghat-eclipse-foundation-identities-importer.yml
@@ -1,0 +1,8 @@
+---
+title: SortingHat Eclipse Foundation identities importer
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Include Eclipse Foundation identities importer for SortingHat
+  in Bitergia Analytics release.


### PR DESCRIPTION
This pull request updates the repository to:

- Add the package `sortinghat-eclipse-foundation` to the release process
- Install the package in the SortingHat images.
- Include the variables needed (user and password) to connect to the API in the settings file
